### PR TITLE
Set audio sample rate automatically from system on Krom Windows builds

### DIFF
--- a/Backends/Krom/Krom.hx
+++ b/Backends/Krom/Krom.hx
@@ -80,7 +80,7 @@ extern class Krom {
 	static function unloadImage(image: kha.Image): Void;
 	static function loadSound(file: String): Dynamic;
 	static function writeAudioBuffer(buffer: js.lib.ArrayBuffer, samples: Int): Void;
-	static function getSampleRate(): Int;
+	static function getSamplesPerSecond(): Int;
 	static function loadBlob(file: String): js.lib.ArrayBuffer;
 
 	static function init(title: String, width: Int, height: Int, samplesPerPixel: Int, vSync: Bool, windowMode: Int, windowFeatures: Int, kromApi: Int): Void;

--- a/Backends/Krom/Krom.hx
+++ b/Backends/Krom/Krom.hx
@@ -80,6 +80,7 @@ extern class Krom {
 	static function unloadImage(image: kha.Image): Void;
 	static function loadSound(file: String): Dynamic;
 	static function writeAudioBuffer(buffer: js.lib.ArrayBuffer, samples: Int): Void;
+	static function getSampleRate(): Int;
 	static function loadBlob(file: String): js.lib.ArrayBuffer;
 
 	static function init(title: String, width: Int, height: Int, samplesPerPixel: Int, vSync: Bool, windowMode: Int, windowFeatures: Int, kromApi: Int): Void;

--- a/Backends/Krom/kha/SystemImpl.hx
+++ b/Backends/Krom/kha/SystemImpl.hx
@@ -171,8 +171,9 @@ class SystemImpl {
 		Krom.setGamepadAxisCallback(gamepadAxisCallback);
 		Krom.setGamepadButtonCallback(gamepadButtonCallback);
 
-		kha.audio2.Audio._init();
+		kha.audio2.Audio.samplesPerSecond = Krom.getSampleRate();
 		kha.audio1.Audio._init();
+		kha.audio2.Audio._init();
 		Krom.setAudioCallback(audioCallback);
 
 		Scheduler.start();

--- a/Backends/Krom/kha/SystemImpl.hx
+++ b/Backends/Krom/kha/SystemImpl.hx
@@ -171,7 +171,7 @@ class SystemImpl {
 		Krom.setGamepadAxisCallback(gamepadAxisCallback);
 		Krom.setGamepadButtonCallback(gamepadButtonCallback);
 
-		kha.audio2.Audio.samplesPerSecond = Krom.getSampleRate();
+		kha.audio2.Audio.samplesPerSecond = Krom.getSamplesPerSecond();
 		kha.audio1.Audio._init();
 		kha.audio2.Audio._init();
 		Krom.setAudioCallback(audioCallback);

--- a/Backends/Krom/kha/audio2/Audio.hx
+++ b/Backends/Krom/kha/audio2/Audio.hx
@@ -10,8 +10,7 @@ class Audio {
 
 	public static function _init() {
 		var bufferSize = 1024 * 2;
-		buffer = new Buffer(bufferSize * 4, 2, 44100);
-		Audio.samplesPerSecond = 44100;
+		buffer = new Buffer(bufferSize * 4, 2, samplesPerSecond);
 	}
 
 	public static function _callCallback(samples: Int): Void {
@@ -32,11 +31,11 @@ class Audio {
 		}
 	}
 
-	public static function _readSample(): Float {
+	public static function _readSample(): FastFloat {
 		if (buffer == null)
 			return 0;
 		var value = buffer.data.get(buffer.readLocation);
-		buffer.readLocation += 1;
+		++buffer.readLocation;
 		if (buffer.readLocation >= buffer.size) {
 			buffer.readLocation = 0;
 		}


### PR DESCRIPTION
@luboslenco This sets the system's sample rate automatically for Krom builds in Windows. Closes [this issue](https://github.com/armory3d/armory/issues/3038). 

I'm opening a [PR for Armorcore](https://github.com/armory3d/armorcore/pull/87) as well that goes together with this.