### PR TITLE
Add stereo panes for Mobile HTML5

### DIFF
--- a/Backends/HTML5/kha/js/MobileWebAudioChannel.hx
+++ b/Backends/HTML5/kha/js/MobileWebAudioChannel.hx
@@ -18,7 +18,7 @@ class MobileWebAudioChannel implements kha.audio1.AudioChannel {
 
 	var leftGain: GainNode;
 	var rightGain: GainNode;
-	var stereoGain: GainNode;
+	var attenuationGain: GainNode;
 	var splitter: ChannelSplitterNode;
 	var merger: ChannelMergerNode;
 
@@ -40,7 +40,7 @@ class MobileWebAudioChannel implements kha.audio1.AudioChannel {
 		leftGain = MobileWebAudio._context.createGain();
 		rightGain = MobileWebAudio._context.createGain();
 		merger = MobileWebAudio._context.createChannelMerger(2);
-		stereoGain = MobileWebAudio._context.createGain();
+		attenuationGain = MobileWebAudio._context.createGain();
 		gain = MobileWebAudio._context.createGain();
 
 		source.connect(splitter);
@@ -48,8 +48,8 @@ class MobileWebAudioChannel implements kha.audio1.AudioChannel {
 		splitter.connect(rightGain, 1);
 		leftGain.connect(merger, 0, 0);
 		rightGain.connect(merger, 0, 1);
-		merger.connect(stereoGain);
-		stereoGain.connect(gain);
+		merger.connect(attenuationGain);
+		attenuationGain.connect(gain);
 
 		gain.connect(MobileWebAudio._context.destination);
 	}

--- a/Backends/HTML5/kha/js/MobileWebAudioChannel.hx
+++ b/Backends/HTML5/kha/js/MobileWebAudioChannel.hx
@@ -18,6 +18,7 @@ class MobileWebAudioChannel implements kha.audio1.AudioChannel {
 
 	var leftGain: GainNode;
 	var rightGain: GainNode;
+	var stereoGain: GainNode;
 	var splitter: ChannelSplitterNode;
 	var merger: ChannelMergerNode;
 
@@ -39,6 +40,7 @@ class MobileWebAudioChannel implements kha.audio1.AudioChannel {
 		leftGain = MobileWebAudio._context.createGain();
 		rightGain = MobileWebAudio._context.createGain();
 		merger = MobileWebAudio._context.createChannelMerger(2);
+		stereoGain = MobileWebAudio._context.createGain();
 		gain = MobileWebAudio._context.createGain();
 
 		source.connect(splitter);
@@ -46,7 +48,8 @@ class MobileWebAudioChannel implements kha.audio1.AudioChannel {
 		splitter.connect(rightGain, 1);
 		leftGain.connect(merger, 0, 0);
 		rightGain.connect(merger, 0, 1);
-		merger.connect(gain);
+		merger.connect(stereoGain);
+		stereoGain.connect(gain);
 
 		gain.connect(MobileWebAudio._context.destination);
 	}

--- a/Backends/HTML5/kha/js/MobileWebAudioChannel.hx
+++ b/Backends/HTML5/kha/js/MobileWebAudioChannel.hx
@@ -2,6 +2,8 @@ package kha.js;
 
 import js.html.audio.AudioBuffer;
 import js.html.audio.AudioBufferSourceNode;
+import js.html.audio.ChannelSplitterNode;
+import js.html.audio.ChannelMergerNode;
 import js.html.audio.GainNode;
 
 class MobileWebAudioChannel implements kha.audio1.AudioChannel {
@@ -13,6 +15,11 @@ class MobileWebAudioChannel implements kha.audio1.AudioChannel {
 	var pauseTime: Float;
 	var paused: Bool = false;
 	var stopped: Bool = false;
+
+	var leftGain: GainNode;
+	var rightGain: GainNode;
+	var splitter: ChannelSplitterNode;
+	var merger: ChannelMergerNode;
 
 	public function new(sound: MobileWebAudioSound, loop: Bool) {
 		this.buffer = sound._buffer;
@@ -27,8 +34,20 @@ class MobileWebAudioChannel implements kha.audio1.AudioChannel {
 		source.onended = function() {
 			stopped = true;
 		}
+
+		splitter = MobileWebAudio._context.createChannelSplitter(2);
+		leftGain = MobileWebAudio._context.createGain();
+		rightGain = MobileWebAudio._context.createGain();
+		merger = MobileWebAudio._context.createChannelMerger(2);
 		gain = MobileWebAudio._context.createGain();
-		source.connect(gain);
+
+		source.connect(splitter);
+		splitter.connect(leftGain, 0);
+		splitter.connect(rightGain, 1);
+		leftGain.connect(merger, 0, 0);
+		rightGain.connect(merger, 0, 1);
+		merger.connect(gain);
+
 		gain.connect(MobileWebAudio._context.destination);
 	}
 


### PR DESCRIPTION
Add left and right gains for initial 3D audio support on mobile browsers. This is intended to work with the [Aura](https://github.com/MoritzBrueckner/aura) plugin.